### PR TITLE
Add additional options

### DIFF
--- a/monitor.go
+++ b/monitor.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"log"
+	"time"
+
+	"github.com/shirou/gopsutil/process"
+)
+
+func Monitor(pid int32, stats chan Stat, done chan struct{}) {
+	proc, err := process.NewProcess(pid)
+	if err != nil {
+		log.Fatal(err)
+	}
+	proc.Percent(0)
+
+	tick := time.Tick(time.Second)
+	for {
+		select {
+		case <-done:
+			return
+		case <-tick:
+			p, err := proc.Percent(0)
+			if err != nil {
+				log.Println(err)
+			} else {
+				select {
+				case stats <- Stat{
+					Label: "CPU",
+					Value: p,
+				}:
+				case <-done:
+					return
+				}
+			}
+		}
+	}
+}

--- a/stat.go
+++ b/stat.go
@@ -14,36 +14,75 @@ type Stat struct {
 	Value float64
 }
 
-func DisplayStats(ch <-chan Stat) {
+func DisplayStats(ch <-chan Stat, done chan struct{}) {
+	type statC struct {
+		Stat
+		Count int
+	}
+
 	var l sync.Mutex
-	entries := map[string]Stat{}
+	avg := make(map[string]*statC)
+	entries := make(map[string]Stat)
 
 	go func() {
 		for {
 			e := <-ch
 			l.Lock()
 			entries[e.Label] = e
+			if _, ok := avg[e.Label]; !ok {
+				avg[e.Label] = &statC{
+					Count: 0,
+					Stat:  e,
+				}
+			}
+			avg[e.Label].Value = (avg[e.Label].Value*float64(avg[e.Label].Count) + e.Value) / float64(avg[e.Label].Count+1)
+			avg[e.Label].Count++
 			l.Unlock()
 		}
 	}()
 
-	for range time.Tick(time.Second) {
-		l.Lock()
-		var entriesSlice []Stat
-		for _, e := range entries {
-			entriesSlice = append(entriesSlice, e)
-		}
-
-		sort.Slice(entriesSlice, func(i, j int) bool {
-			return strings.Compare(entriesSlice[i].Label, entriesSlice[j].Label) < 0
+	printLine := func(entries []Stat) {
+		sort.Slice(entries, func(i, j int) bool {
+			return strings.Compare(entries[i].Label, entries[j].Label) < 0
 		})
 		var s []string
-		for _, e := range entriesSlice {
-			s = append(s, fmt.Sprintf("%s: %f", e.Label, e.Value))
+		for _, e := range entries {
+			s = append(s, fmt.Sprintf("%s: %.2f", e.Label, e.Value))
 		}
 
 		log.Println(strings.Join(s, ", "))
-		entriesSlice = entriesSlice[:0]
-		l.Unlock()
+	}
+
+	start := time.Now()
+	tick := time.Tick(time.Second)
+
+	for {
+		select {
+		case <-done:
+			l.Lock()
+			entriesSlice := []Stat{{
+				Label: "Runtime (s)",
+				Value: time.Since(start).Seconds(),
+			}}
+			for _, e := range avg {
+				entriesSlice = append(entriesSlice, e.Stat)
+			}
+
+			log.Println("====== Summary ======")
+			printLine(entriesSlice)
+			l.Unlock()
+			return
+		case <-tick:
+			l.Lock()
+			var entriesSlice []Stat
+			for _, e := range entries {
+				entriesSlice = append(entriesSlice, e)
+			}
+
+			printLine(entriesSlice)
+
+			entriesSlice = entriesSlice[:0]
+			l.Unlock()
+		}
 	}
 }


### PR DESCRIPTION
* `-time` allows to run the benchmark for a configured period of time
* `-monitor` receives a PID to monitor during the benchmark
* `-late-ratio` gives a ratio of queries to run with a "late" index