### PR TITLE
Allow ?cached blockings queries

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ Usage of consul-bench:
     	If -register is given, flap each instance between critical and passing state on given interval
   -query-stale
     	Run stale blocking queries
+  -cached
+      Run cached blocking queries
   -query-wait duration
     	Bloquing queries max wait time (default 10m0s)
   -register int

--- a/main.go
+++ b/main.go
@@ -23,6 +23,7 @@ func main() {
 	flapInterval := flag.Duration("flap-interval", 0, "If -register is given, flap each instance between critical and passing state on given interval")
 	wait := flag.Duration("query-wait", 10*time.Minute, "Bloquing queries max wait time")
 	stale := flag.Bool("query-stale", false, "Run stale blocking queries")
+	cached := flag.Bool("cached", false, "Run cached blocking queries")
 	token := flag.String("token", "", "ACL token")
 	watchers := flag.Int("watchers", 1, "Number of concurrnet watchers on service")
 	monitor := flag.Int("monitor", 0, "Consul PID")
@@ -77,9 +78,9 @@ func main() {
 
 	var qf queryFn
 	if !*useRPC {
-		qf = QueryAgent(c, *serviceName, *wait, *stale)
+		qf = QueryAgent(c, *serviceName, *wait, *stale, *cached)
 	} else {
-		qf = QueryServer(*rpcAddr, *dc, *serviceName, *wait, *stale)
+		qf = QueryServer(*rpcAddr, *dc, *serviceName, *wait)
 	}
 
 	wg.Add(1)

--- a/query.go
+++ b/query.go
@@ -68,12 +68,13 @@ func RunQueries(fn queryFn, count int, lateRatio float64, stats chan Stat, done 
 	return nil
 }
 
-func QueryAgent(client *consul.Client, serviceName string, wait time.Duration, allowStale bool) queryFn {
+func QueryAgent(client *consul.Client, serviceName string, wait time.Duration, allowStale bool, cached bool) queryFn {
 	return func(index uint64) (uint64, error) {
 		_, meta, err := client.Health().Service(serviceName, "", false, &consul.QueryOptions{
-			WaitTime:   wait,
-			WaitIndex:  index,
-			AllowStale: allowStale,
+			WaitTime:    wait,
+			WaitIndex:   index,
+			AllowStale:  allowStale,
+			UseCache: cached,
 		})
 		if err != nil {
 			return 0, err
@@ -83,7 +84,7 @@ func QueryAgent(client *consul.Client, serviceName string, wait time.Duration, a
 	}
 }
 
-func QueryServer(addr string, dc string, serviceName string, wait time.Duration, allowStale bool) queryFn {
+func QueryServer(addr string, dc string, serviceName string, wait time.Duration) queryFn {
 	connPool := &pool.ConnPool{
 		SrcAddr:    nil,
 		LogOutput:  os.Stderr,


### PR DESCRIPTION
Looking at https://www.hashicorp.com/blog/announcing-hashicorp-consul-1-9#streaming, cached queries are necessary in order to use streaming. Patch is tested on local agent, ?cached= is properly added with flag.